### PR TITLE
add property to switch off persistent disk checking

### DIFF
--- a/jobs/etcd/spec
+++ b/jobs/etcd/spec
@@ -24,3 +24,6 @@ properties:
   etcd.log_sync_timeout_in_seconds:
     description: "Time to wait for a joining node to finish syncing logs with the existing cluster in seconds"
     default: 30
+  etcd.check_for_persistent_disk:
+    description: "Check if a persistent disk is mounted for etcd"
+    default: true

--- a/jobs/etcd/templates/etcd_ctl.erb
+++ b/jobs/etcd/templates/etcd_ctl.erb
@@ -26,9 +26,11 @@ case $1 in
 
     pid_guard ${PIDFILE} "etcd"
 
-    if ! mountpoint -q ${STORE_DIR}; then
-      echo "$STORE_DIR must be a persistent disk"
-      exit 1
+    if <%= p("etcd.check_for_persistent_disk") %>; then
+      if ! mountpoint -q ${STORE_DIR}; then
+        echo "$STORE_DIR must be a persistent disk"
+        exit 1
+      fi
     fi
 
     mkdir -p ${RUN_DIR}


### PR DESCRIPTION
Allows for switching of the mountpoint checking of /var/vcap/store, to be able to have a cloudfoundry installation without any attached disks.
This was already possible before, but since cf-210 the etcd job was switched and symlinked to this repo, which contains the mountpoint check previously not found in the etcd job of cf-release.

Signed-off-by: Fabio Berchtold <fabio.berchtold@swisscom.com>