### PR TITLE
Include licenses in the final bosh tarball.

### DIFF
--- a/packages/etcd_metrics_server/spec
+++ b/packages/etcd_metrics_server/spec
@@ -6,3 +6,5 @@ dependencies:
 
 files:
   - etcd-metrics-server/**/*.go
+  - etcd-metrics-server/**/LICENSE
+  - etcd-metrics-server/**/NOTICE


### PR DESCRIPTION
- Because there is no proper attribution of the vendored dependencies,
  use a wildcard to keep all licenses in place.