### PR TITLE
DNS suffix customization

### DIFF
--- a/jobs/etcd/spec
+++ b/jobs/etcd/spec
@@ -60,3 +60,7 @@ properties:
   etcd.dns_health_check_host:
     description: "Host to ping for confirmation of DNS resolution"
     default: "consul.service.cf.internal"
+
+  etcd.advertise_urls_dns_suffix:
+    description: "DNS suffix for all nodes in the etcd cluster"
+    default: "etcd.service.cf.internal"

--- a/jobs/etcd/templates/etcd_bosh_utils.sh.erb
+++ b/jobs/etcd/templates/etcd_bosh_utils.sh.erb
@@ -27,11 +27,13 @@ node_name="<%= name.gsub('_', '-') %>-<%= spec.index %>"
   client_protocol = p("etcd.require_ssl") ? "https" : "http"
   peer_protocol = p("etcd.peer_require_ssl") ? "https" : "http"
 
+  dns_suffix = p("etcd.advertise_urls_dns_suffix")
+
   if p("etcd.require_ssl") || p("etcd.peer_require_ssl")
     cluster_members = p("etcd.cluster").map do |zone|
       result = []
       for i in 0..zone["instances"]-1
-        result << "#{client_protocol}://#{zone["name"].gsub('_', '-')}-#{i}.etcd.service.cf.internal:4001"
+        result << "#{client_protocol}://#{zone["name"].gsub('_', '-')}-#{i}.#{dns_suffix}:4001"
       end
       result
     end.flatten.join(",")
@@ -46,8 +48,8 @@ peer_protocol=<%= peer_protocol %>
 listen_peer_url="${peer_protocol}://0.0.0.0:7001"
 
 <% if p("etcd.require_ssl") || p("etcd.peer_require_ssl") %>
-advertise_peer_url="${peer_protocol}://${node_name}.etcd.service.cf.internal:7001"
-advertise_client_url="${client_protocol}://${node_name}.etcd.service.cf.internal:4001"
+advertise_peer_url="${peer_protocol}://${node_name}.<%= dns_suffix %>:7001"
+advertise_client_url="${client_protocol}://${node_name}.<%= dns_suffix %>:4001"
 <% else %>
 advertise_peer_url="http://<%= my_ip %>:7001"
 advertise_client_url="http://<%= my_ip %>:4001"

--- a/manifest-generation/bosh-lite-stubs/property-overrides.yml
+++ b/manifest-generation/bosh-lite-stubs/property-overrides.yml
@@ -2,3 +2,4 @@ property_overrides:
   etcd:
     require_ssl: false
     peer_require_ssl: false
+    advertise_urls_dns_suffix: "etcd.service.cf.internal"

--- a/manifest-generation/etcd.yml
+++ b/manifest-generation/etcd.yml
@@ -74,6 +74,7 @@ properties:
     peer_ca_cert: (( property_overrides.etcd.peer_ca_cert || nil ))
     peer_cert: (( property_overrides.etcd.peer_cert || nil ))
     peer_key: (( property_overrides.etcd.peer_key || nil ))
+    advertise_urls_dns_suffix: (( property_overrides.etcd.advertise_urls_dns_suffix ))
 
 # The keys below should not be included in the final stub
 release_version: (( release_version_overrides || "latest" ))


### PR DESCRIPTION
There was some short [discussion] on #integration, but I'm certainly up for more if that's desired.  This is basically somewhere that lets me keep track of what's going on :)

This allows changing the DNS suffix used to look for other etcd nodes (instead of consul's `etcd.service.cf.internal`), for cases where a different service discovery mechanism is being used.  If this lands as-is, the next step is to update manifest generation in cf-release and diego-release (anything else?) to add the property, then remove the default from the spec.

(I can't quite tell from the git history if I should be working from `develop` or `master`; the README wasn't very enlightening on that aspect.  I'd be happy to rebase or whatever else to make the code sensible, first.)

If opening a story in a tracker to coordinate dealing with `cf-release` / `diego-release` is preferable, that's fine too, though it would be a bit harder for me to help out :)

[discussion]: https://cloudfoundry.slack.com/archives/infrastructure/p1456964046000559