### PR TITLE
Advertisement DNS suffix customization: remove default

### DIFF
--- a/jobs/etcd/spec
+++ b/jobs/etcd/spec
@@ -63,4 +63,3 @@ properties:
 
   etcd.advertise_urls_dns_suffix:
     description: "DNS suffix for all nodes in the etcd cluster"
-    default: "etcd.service.cf.internal"


### PR DESCRIPTION
As requested when discussing the original request from #9.

Relevant PRs adding defaults:
- cloudfoundry/cf-release#928
- cloudfoundry-incubator/diego-release#143
- pivotal-cf-experimental/destiny#1

I'm unsure how to ensure that other people are aware of the requirement.  Mail to `cf-dev@`? Relnotes?