### PR TITLE
Make ips configurable

### DIFF
--- a/jobs/etcd/spec
+++ b/jobs/etcd/spec
@@ -58,6 +58,10 @@ properties:
   etcd.client_key:
     description: "PEM-encoded client key"
 
+  etcd.client_ip:
+    description: "IP for etcd client"
+    default: "0.0.0.0"
+
   etcd.peer_require_ssl:
     description: "enable ssl between etcd peers"
     default: true
@@ -70,6 +74,10 @@ properties:
 
   etcd.peer_key:
     description: "PEM-encoded peer key"
+
+  etcd.peer_ip:
+    description: "IP for etcd peer"
+    default: "0.0.0.0"
 
   etcd.dns_health_check_host:
     description: "Host to ping for confirmation of DNS resolution"

--- a/jobs/etcd/templates/etcd_bosh_utils.sh.erb
+++ b/jobs/etcd/templates/etcd_bosh_utils.sh.erb
@@ -43,7 +43,7 @@ node_name="<%= name.gsub('_', '-') %>-<%= spec.index %>"
 
 client_protocol=<%= client_protocol %>
 peer_protocol=<%= peer_protocol %>
-listen_peer_url="${peer_protocol}://0.0.0.0:7001"
+listen_peer_url="${peer_protocol}://<%= p("etcd.peer_ip") %>:7001"
 cluster_members=<%= cluster_members.gsub(" ", ",") %>
 
 <% if p("etcd.require_ssl") || p("etcd.peer_require_ssl") %>
@@ -54,7 +54,7 @@ advertise_peer_url="http://<%= my_ip %>:7001"
 advertise_client_url="http://<%= my_ip %>:4001"
 <% end %>
 
-listen_client_url="${client_protocol}://0.0.0.0:4001"
+listen_client_url="${client_protocol}://<%= p("etcd.client_ip") %>:4001"
 this_node="${node_name}=${advertise_peer_url}"
 
 <% if p("etcd.require_ssl") || p("etcd.peer_require_ssl") %>

--- a/jobs/etcd_proxy/spec
+++ b/jobs/etcd_proxy/spec
@@ -35,3 +35,7 @@ properties:
   etcd_proxy.port:
     description: "port of proxy server"
     default: 4001
+
+  etcd_proxy.ip:
+    description: "IP of proxy server"
+    default: "0.0.0.0"

--- a/jobs/etcd_proxy/templates/etcd_proxy_ctl.erb
+++ b/jobs/etcd_proxy/templates/etcd_proxy_ctl.erb
@@ -32,6 +32,7 @@ function start_etcd_proxy() {
   -etcd-dns-suffix=<%= p("etcd_proxy.etcd.dns_suffix") %> \
   -etcd-port=<%= p("etcd_proxy.etcd.port") %> \
   -port=<%= p("etcd_proxy.port") %> \
+  -ip=<%= p("etcd_proxy.ip") %> \
   -cacert=${CERTS_DIR}/ca.crt \
   -cert=${CERTS_DIR}/client.crt \
   -key=${CERTS_DIR}/client.key \

--- a/src/etcd-proxy/etcd_proxy.go
+++ b/src/etcd-proxy/etcd_proxy.go
@@ -19,6 +19,7 @@ import (
 type Flags struct {
 	EtcdDNSSuffix  string
 	EtcdPort       string
+	IP             string
 	Port           string
 	CACertFilePath string
 	CertFilePath   string
@@ -29,6 +30,7 @@ func main() {
 	flags := Flags{}
 	flag.StringVar(&flags.EtcdDNSSuffix, "etcd-dns-suffix", "", "domain of etcd cluster")
 	flag.StringVar(&flags.EtcdPort, "etcd-port", "4001", "port that etcd server is running on")
+	flag.StringVar(&flags.IP, "ip", "", "ip of the proxy server")
 	flag.StringVar(&flags.Port, "port", "", "port of the proxy server")
 	flag.StringVar(&flags.CACertFilePath, "cacert", "", "path to the etcd ca certificate")
 	flag.StringVar(&flags.CertFilePath, "cert", "", "path to the etcd client certificate")
@@ -72,7 +74,7 @@ func main() {
 		proxy.ServeHTTP(w, r)
 	})
 
-	if err := http.ListenAndServe(":"+flags.Port, nil); err != nil {
+	if err := http.ListenAndServe(flags.IP+":"+flags.Port, nil); err != nil {
 		fail(err)
 	}
 }


### PR DESCRIPTION
We need to specify specific addresses for the etcd components to bind to (i.e. localhost). This makes the addresses configurable via the bosh manifest with default of `0.0.0.0`.

Thanks,
@mdelillo @chhhavi