### PR TITLE
lazy etcd version detection - allow version change via blobs/etcd/* only

### DIFF
--- a/packages/etcd/packaging
+++ b/packages/etcd/packaging
@@ -1,4 +1,4 @@
 set -e -x
 
-tar xzf etcd/etcd-v2.2.0-tls1.2-patch-linux-amd64.tar.gz
-cp -R etcd-v2.2.0-tls1.2-patch-linux-amd64/* ${BOSH_INSTALL_TARGET}
+tar xzf etcd/etcd-*-linux-amd64.tar.gz
+cp -R etcd-*-linux-amd64/* ${BOSH_INSTALL_TARGET}

--- a/packages/etcd/spec
+++ b/packages/etcd/spec
@@ -2,4 +2,4 @@
 name: etcd
 
 files:
-  - etcd/etcd-v2.2.0-tls1.2-patch-linux-amd64.tar.gz
+  - etcd/etcd-*-linux-amd64.tar.gz


### PR DESCRIPTION
This PR allows developers to trial new etcd blobs by removing the existing `blobs/etcd/*` and dropping in their new one.

Depending on bosh cli, develop may have to clean out `.blobs` and `config/blobs.yml` to avoid repo's built in etcd-v2.2.0 