### PR TITLE
Fix wrong test for next versions of Go

### DIFF
--- a/src/etcd-proxy/etcd_proxy_test.go
+++ b/src/etcd-proxy/etcd_proxy_test.go
@@ -340,7 +340,7 @@ var _ = Describe("provides an http proxy to an etcd cluster", func() {
 			command := exec.Command(pathToEtcdProxy,
 				"--etcd-dns-suffix", etcdServerHost,
 				"--etcd-port", etcdServerPort,
-				"--ip", "%%%",
+				"--ip", "+++",
 				"--port", port,
 				"--cacert", caCertFilePath,
 				"--cert", clientCertFilePath,
@@ -351,7 +351,7 @@ var _ = Describe("provides an http proxy to an etcd cluster", func() {
 
 			Expect(err).NotTo(HaveOccurred())
 			Expect(session.ExitCode()).To(Equal(1))
-			Expect(session.Err.Contents()).To(ContainSubstring("missing brackets in address"))
+			Expect(session.Err.Contents()).To(ContainSubstring("listen tcp: lookup +++: no such host"))
 		})
 	})
 })


### PR DESCRIPTION
* Expectation used some internals of Go. This has been changed in
https://github.com/golang/go/commit/dc74f51c43f2b17186e2c338e8ee29be3f2dd8d4
Binary still fails but output is different.

`+++` fail with the same output in Go 1.8 & Go 1.9

Signed-off-by: Oleksandr Slynko <oslynko@pivotal.io>